### PR TITLE
fix: Add Hasura admin URL to extension CSP and host permissions

### DIFF
--- a/chrome-extension/content/content.js
+++ b/chrome-extension/content/content.js
@@ -160,7 +160,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 // Listen for messages from the web page
 window.addEventListener('message', (event) => {
   // Only accept messages from todzz.eu or localhost
-  const allowedOrigins = ['https://todzz.eu', 'https://www.todzz.eu', 'http://localhost:5173'];
+  const allowedOrigins = ['https://todzz.eu', 'https://www.todzz.eu', 'https://todzz.admin.servicehost.io', 'http://localhost:5173'];
   if (!allowedOrigins.includes(event.origin)) {
     return;
   }

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -12,6 +12,7 @@
   "host_permissions": [
     "https://todzz.eu/*",
     "https://www.todzz.eu/*",
+    "https://todzz.admin.servicehost.io/*",
     "http://localhost:5173/*"
   ],
   "action": {
@@ -38,6 +39,6 @@
     "128": "icons/icon128.png"
   },
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; connect-src https://todzz.eu https://www.todzz.eu http://localhost:5173 http://localhost:3001;"
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src https://todzz.eu https://www.todzz.eu https://todzz.admin.servicehost.io http://localhost:5173 http://localhost:3001;"
   }
 }


### PR DESCRIPTION
The extension was being blocked from connecting to the Hasura admin URL (https://todzz.admin.servicehost.io) due to CSP restrictions.

Changes:
- Added todzz.admin.servicehost.io to CSP connect-src
- Added todzz.admin.servicehost.io to host_permissions
- Added todzz.admin.servicehost.io to content script allowed origins

This allows the extension to connect to the production Hasura instance.