### PR TITLE
fix: Add npm run generate to build script for Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"generate": "graphql-codegen --require dotenv/config && node fix-imports.cjs",
 		"dev": "npm run generate && vite dev",
-		"build": "vite build",
+		"build": "npm run generate && vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "NODE_OPTIONS='--max-old-space-size=4096' svelte-kit sync && NODE_OPTIONS='--max-old-space-size=4096' svelte-check --tsconfig ./tsconfig.json",


### PR DESCRIPTION
The build script was not generating GraphQL types during deployment, causing queries to fail with '[object Object]' error in production.

This ensures types are generated before building on Vercel.

Related to: task 028 - speed optimization