### PR TITLE
perf: Fix N+1 query problem - use single request instead of chunked l…

### DIFF
--- a/src/routes/[lang]/[username]/[board]/+page.svelte
+++ b/src/routes/[lang]/[username]/[board]/+page.svelte
@@ -102,14 +102,12 @@
 				const needsToLoadTodos = !notMember && (!todosStore.initialized || todosStore.currentBoardId !== board.id);
 
 				if (needsToLoadTodos) {
-					// Load initial todos (top 50 with minimal data)
+					// Load ALL todos with minimal data in ONE request
+					// This avoids N+1 query problem from chunked loading
 					await todosStore.loadTodosInitial(board.id);
 
-					// Load remaining todos AFTER LCP (delayed to avoid blocking paint)
-					// Increased from 100ms to 2000ms to ensure it doesn't interfere with LCP
-					setTimeout(() => {
-						todosStore.loadTodosRemaining(board.id);
-					}, 2000);
+					// No background loading - everything loaded upfront with minimal payload
+					// The minimal fragment keeps payload small while loading all data
 				}
 
 				boardNotFound = false;


### PR DESCRIPTION
…oading

PROBLEM IDENTIFIED:
The previous chunked loading approach created dozens of small GraphQL requests, causing significant network overhead and slower performance (7.6-7.7s LCP).

Network analysis showed:
- 185+ requests total
- Dozens of identical 'graphql' requests
- Each 0.3-6.6 kB (tiny but lots of overhead)
- Each 18-39ms latency
- Classic N+1 query anti-pattern

ROOT CAUSE:
1. loadTodosInitial() loaded 50 todos
2. loadTodosRemaining() made MULTIPLE chunked requests in a while loop
3. Each chunk = network round-trip overhead
4. Dozens of requests × 30ms each = 900ms+ in network overhead alone
5. Sequential requests blocked main thread

SOLUTION:
Replace chunked loading with ONE request using minimal fragment:
- Load ALL todos (up to 1000) in a SINGLE request
- Use TODO_MINIMAL_FRAGMENT (40-60% smaller payload)
- Include both active and completed todos
- Sort by completed_at (active first) + sort_order

CHANGES:
- src/routes/[lang]/[username]/[board]/+page.svelte:
  * Remove loadTodosRemaining() call
  * Comment explains single-request strategy

- src/lib/stores/todos.svelte.ts:
  * loadTodosInitial(): Load all todos, not just 50
  * Remove limit of 50, increase to 1000
  * Remove completed_at filter (load all)
  * Sort active todos first

EXPECTED RESULTS:
- Network tab: 1-2 GraphQL requests instead of dozens
- LCP: Should improve from 7.6-7.7s back to ~7s or better
- Payload: Still 40-60% smaller due to minimal fragment
- Localhost: Much better (fewer requests = less overhead)
- Production: Even better (smaller payload + HTTP/2)

TRADEOFFS:
- Initial payload larger than 50-todo version
- But MUCH smaller than original full-fragment version
- Net win: 1 medium request >> dozens of tiny requests