### PR TITLE
perf: Reduce from dozens of requests to 3 total requests

### DIFF
--- a/src/routes/[lang]/[username]/[board]/+page.svelte
+++ b/src/routes/[lang]/[username]/[board]/+page.svelte
@@ -102,12 +102,14 @@
 				const needsToLoadTodos = !notMember && (!todosStore.initialized || todosStore.currentBoardId !== board.id);
 
 				if (needsToLoadTodos) {
-					// Load ALL todos with minimal data in ONE request
-					// This avoids N+1 query problem from chunked loading
+					// Load first 50 active todos for fast initial render
 					await todosStore.loadTodosInitial(board.id);
 
-					// No background loading - everything loaded upfront with minimal payload
-					// The minimal fragment keeps payload small while loading all data
+					// Load remaining in background (non-blocking)
+					// Uses 2 requests total to avoid N+1 problem
+					setTimeout(() => {
+						todosStore.loadTodosRemaining(board.id);
+					}, 100);
 				}
 
 				boardNotFound = false;


### PR DESCRIPTION
PROBLEM:
Previous attempt created 800x performance regression (6.7ms → 5.35s) by removing background loading and making everything synchronous.

ROOT CAUSE ANALYSIS:
1. Original code: Load 50 initial + chunked background (while loop) = N+1 problem
2. First fix attempt: Removed background, loaded everything upfront = blocking
3. Result: Page couldn't render until ALL data loaded = terrible UX

NEW APPROACH:
Restore the load-then-background pattern but eliminate N+1:

Request Flow:
1. Initial: Load first 50 active todos (GET_TODOS_MINIMAL)
   - Fast, non-blocking
   - Page renders immediately

2. Background (after 100ms):
   - Request 1: Remaining active todos (offset 50, limit 950)
   - Request 2: Completed todos (limit 100)
   - Total: 2 background requests

TOTAL REQUESTS: 3 (vs dozens before)

Comparison:
| Approach | Requests | Blocking | Performance |
|----------|----------|----------|-------------|
| Original | 20-50+ (while loop) | Partial | Slow (7s LCP) | | "Fix" attempt 1 | 1 (all upfront) | Full | Terrible (5.35s) | | This fix | 3 (initial + 2 bg) | Minimal | Fast ✅ |

CHANGES:
- loadTodosInitial(): Back to loading 50 active todos only
- loadTodosRemaining(): Simplified to 2 requests (no while loop!)
- Page: Restored background loading with setTimeout(100ms)

EXPECTED RESULTS:
- Network tab: 3 GraphQL requests (not dozens)
- Initial render: Fast (<1s)
- LCP: Should match or beat original ~7s
- Payload: 40-60% smaller due to minimal fragment