### PR TITLE
refactor: Use todo alias instead of UUID in card URLs

### DIFF
--- a/src/lib/components/activity/BoardActivityList.svelte
+++ b/src/lib/components/activity/BoardActivityList.svelte
@@ -141,20 +141,20 @@
 		}
 
 		// Navigate to the card modal
-		if (log.todo_id) {
+		if (log.todo?.alias) {
 			// Close the activity modal first
 			onClose?.();
 
 			const currentUrl = $page.url;
 			const newUrl = new URL(currentUrl);
-			newUrl.searchParams.set('card', log.todo_id);
+			newUrl.searchParams.set('card', log.todo.alias);
 			goto(newUrl.toString());
 		}
 	}
 
 	function isClickable(log: any): boolean {
 		// Only make clickable if the todo still exists (not deleted)
-		return log.action_type !== 'deleted' && log.todo_id;
+		return log.action_type !== 'deleted' && log.todo?.alias;
 	}
 </script>
 

--- a/src/lib/components/notifications/NotificationPanel.svelte
+++ b/src/lib/components/notifications/NotificationPanel.svelte
@@ -84,9 +84,9 @@
 		const board = notification.todo.list.board;
 		const boardAlias = board.alias;
 		const username = board.user?.username;
-		const cardId = notification.todo_id;
+		const cardAlias = notification.todo.alias;
 
-		if (!boardAlias || !username || !cardId) {
+		if (!boardAlias || !username || !cardAlias) {
 			return;
 		}
 
@@ -94,7 +94,7 @@
 		const lang = getEffectiveLocale($page.params.lang, userStore.user?.locale);
 
 		// Navigate to the card
-		const url = `/${lang}/${username}/${boardAlias}?card=${cardId}`;
+		const url = `/${lang}/${username}/${boardAlias}?card=${cardAlias}`;
 
 		// Mark as read when clicking
 		if (!notification.is_read) {

--- a/src/lib/components/notifications/UnifiedNotificationBell.svelte
+++ b/src/lib/components/notifications/UnifiedNotificationBell.svelte
@@ -182,9 +182,9 @@
 		const board = notification.todo.list.board;
 		const boardAlias = board.alias;
 		const username = board.user?.username;
-		const cardId = notification.todo_id;
+		const cardAlias = notification.todo.alias;
 
-		if (!boardAlias || !username || !cardId) {
+		if (!boardAlias || !username || !cardAlias) {
 			return;
 		}
 
@@ -192,7 +192,7 @@
 		const lang = getEffectiveLocale($page.params.lang, userStore.user?.locale);
 
 		// Navigate to the card
-		const url = `/${lang}/${username}/${boardAlias}?card=${cardId}`;
+		const url = `/${lang}/${username}/${boardAlias}?card=${cardAlias}`;
 
 		// Mark as read when clicking
 		if (!notification.is_read) {

--- a/src/lib/components/todo/TodoItem.svelte
+++ b/src/lib/components/todo/TodoItem.svelte
@@ -405,7 +405,7 @@
 			event.preventDefault();
 			return;
 		}
-		goto(`/${lang}/${username}/${boardAlias}?card=${todo.id}`);
+		goto(`/${lang}/${username}/${boardAlias}?card=${todo.alias}`);
 	}
 </script>
 
@@ -437,7 +437,7 @@
 		>
 			{#if !isEditing}
 				<a
-					href="/{lang}/{username}/{boardAlias}?card={todo.id}"
+					href="/{lang}/{username}/{boardAlias}?card={todo.alias}"
 					data-sveltekit-preload-data="hover"
 					data-sveltekit-noscroll
 					class="block"

--- a/src/lib/graphql/documents.ts
+++ b/src/lib/graphql/documents.ts
@@ -4,6 +4,7 @@ import { graphql } from './generated';
 export const TODO_FRAGMENT = graphql(`
 	fragment TodoFields on todos {
 		id
+		alias
 		title
 		content
 		due_on
@@ -902,6 +903,7 @@ export const ACTIVITY_LOG_FRAGMENT = graphql(`
 		}
 		todo {
 			id
+			alias
 			title
 			list {
 				id

--- a/src/routes/[lang]/[username]/[board]/+page.svelte
+++ b/src/routes/[lang]/[username]/[board]/+page.svelte
@@ -434,7 +434,7 @@
 
 	{#if openCardId}
 		<CardModal
-			cardId={openCardId}
+			cardAlias={openCardId}
 			{lang}
 			onClose={() => goto(`/${lang}/${username}/${boardAlias}`)}
 		/>

--- a/src/routes/[lang]/[username]/[board]/CardModal.svelte
+++ b/src/routes/[lang]/[username]/[board]/CardModal.svelte
@@ -11,7 +11,7 @@
 	import CardDetailView from '$lib/components/todo/CardDetailView.svelte';
 	import type { TodoFieldsFragment } from '$lib/graphql/generated/graphql';
 
-	let { cardId, lang, onClose }: { cardId: string; lang: string; onClose: () => void } = $props();
+	let { cardAlias, lang, onClose }: { cardAlias: string; lang: string; onClose: () => void } = $props();
 
 	let todo = $state<TodoFieldsFragment | null>(null);
 	let loading = $state(true);
@@ -23,7 +23,7 @@
 	});
 
 	$effect(() => {
-		const foundTodo = todosStore.todos.find((t) => t.id === cardId);
+		const foundTodo = todosStore.todos.find((t) => t.alias === cardAlias);
 		if (foundTodo && todo) {
 			todo = foundTodo;
 		}
@@ -38,10 +38,10 @@
 			await new Promise((resolve) => setTimeout(resolve, 50));
 		}
 
-		const foundTodo = todosStore.todos.find((t) => t.id === cardId);
+		const foundTodo = todosStore.todos.find((t) => t.alias === cardAlias);
 		if (foundTodo) {
 			todo = foundTodo;
-			await commentsStore.loadComments(cardId);
+			await commentsStore.loadComments(foundTodo.id);
 		}
 		loading = false;
 	});


### PR DESCRIPTION
Change card URL query parameter from UUID-based to alias-based for better SEO and user-friendly URLs.

Changes:
- Update TODO_FRAGMENT to include alias field
- Update ACTIVITY_LOG_FRAGMENT to include alias in todo object
- Refactor CardModal to accept and lookup by cardAlias instead of cardId
- Update TodoItem navigation to use todo.alias in URLs
- Update notification components (NotificationPanel, UnifiedNotificationBell) to use todo.alias when constructing card URLs
- Update BoardActivityList to use todo.alias for activity log links

The URL pattern changes from:
  /{lang}/{username}/{board}?card={uuid} To:
  /{lang}/{username}/{board}?card={alias}

Note: GraphQL types will need to be regenerated via 'npm run generate' once the environment is properly configured with .env file.