### PR TITLE
fix: Search subnotes recursively when selecting notes

### DIFF
--- a/src/lib/components/notes/NotesView.svelte
+++ b/src/lib/components/notes/NotesView.svelte
@@ -18,9 +18,25 @@
 	let selectedNoteId: string | null = $state(null);
 	let saving: boolean = $state(false);
 
+	// Recursive function to find a note by ID in the hierarchy
+	function findNoteById(notes: any[], noteId: string | null): any | null {
+		if (!noteId) return null;
+
+		for (const note of notes) {
+			if (note.id === noteId) {
+				return note;
+			}
+			// Search in subnotes recursively
+			if (note.subnotes && note.subnotes.length > 0) {
+				const found = findNoteById(note.subnotes, noteId);
+				if (found) return found;
+			}
+		}
+		return null;
+	}
+
 	const selectedNote = $derived.by(() => {
-		const found = notesStore.sortedNotes.find((n) => n.id === selectedNoteId) || null;
-		return found;
+		return findNoteById(notesStore.sortedNotes, selectedNoteId);
 	});
 
 	onMount(async () => {


### PR DESCRIPTION
Add recursive findNoteById() function to properly find and display subnotes when they are selected. Previously, only top-level notes could be found in the flat sortedNotes array, causing subnotes to show 'Select a note to view' message instead of loading the editor.

The function now traverses the entire note hierarchy recursively to find notes at any depth level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)