### PR TITLE
Fix browser title showing undefined on card open

### DIFF
--- a/src/routes/[lang]/[username]/[board]/+page.svelte
+++ b/src/routes/[lang]/[username]/[board]/+page.svelte
@@ -214,7 +214,7 @@
 <svelte:head>
 	<title
 		>{openCardId
-			? todosStore.todos.find((t) => t.id === openCardId)?.title +
+			? todosStore.todos.find((t) => t.alias === openCardId)?.title +
 				' @ ' +
 				listsStore.selectedBoard?.name
 			: listsStore.selectedBoard?.name} | ToDzz</title


### PR DESCRIPTION
The browser title was incorrectly searching for todos by id instead of alias. When opening a card via URL parameter ?card=<alias>, the title would show "Undefined" because it couldn't find a matching todo.

**Fix**: Changed the todo lookup in <svelte:head> title from:
- `todosStore.todos.find((t) => t.id === openCardId)`
- to `todosStore.todos.find((t) => t.alias === openCardId)`

This now correctly displays the todo title in the browser title, e.g.: "My Task Title @ Board Name | ToDzz"

Location: src/routes/[lang]/[username]/[board]/+page.svelte:217